### PR TITLE
0.5.0

### DIFF
--- a/Core/Globals.as
+++ b/Core/Globals.as
@@ -1,9 +1,10 @@
 /*
 c 2023-06-10
-m 2023-07-19
+m 2023-07-20
 */
 
 const string BLUE   = "\\$09D";
+const string CYAN   = "\\$2FF";
 const string GRAY   = "\\$888";
 const string GREEN  = "\\$0D2";
 const string ORANGE = "\\$F90";
@@ -20,6 +21,7 @@ bool   ForcedAccel;
 string ForcedAccelColor;
 // bool Fragile;
 string FragileColor = DefaultColor;
+uint   LastTurboLevel;
 bool   NoBrakes;
 string NoBrakesColor;
 bool   NoEngine;

--- a/Core/Globals.as
+++ b/Core/Globals.as
@@ -1,6 +1,6 @@
 /*
 c 2023-06-10
-m 2023-06-10
+m 2023-07-19
 */
 
 const string BLUE   = "\\$09D";
@@ -31,6 +31,7 @@ string NoSteerColor;
 // bool   Penalty;
 string PenaltyColor = DefaultColor;
 string ReactorColor;
+float  ReactorFinalCountdown;
 string ReactorIcon = Icons::Rocket;
 uint   ReactorLevel;
 uint   ReactorType;

--- a/Core/Globals.as
+++ b/Core/Globals.as
@@ -39,3 +39,4 @@ float  SlowMo;
 string SlowMoColor;
 bool   Turbo;
 string TurboColor;
+float  TurboTime;

--- a/Core/Util.as
+++ b/Core/Util.as
@@ -1,6 +1,6 @@
 /*
 c 2023-06-10
-m 2023-06-10
+m 2023-07-19
 */
 
 // Will be written out when VehicleState is updated
@@ -31,6 +31,22 @@ bool IsSameVehicle(CSceneVehicleVis@ a, CSceneVehicleVis@ b) {
     if (a.AsyncState.Position.y != b.AsyncState.Position.y) return false;
     if (a.AsyncState.Position.z != b.AsyncState.Position.z) return false;
     return true;
+}
+
+string ReactorText(float c) {
+    if (c == 0)   return ReactorColor + ReactorIcon + "  Reactor Boost";
+    if (c < 0.09) return ReactorColor + ReactorIcon + "  Reactor Boos" + DefaultColor + "t";
+    if (c < 0.17) return ReactorColor + ReactorIcon + "  Reactor Boo" + DefaultColor + "st";
+    if (c < 0.25) return ReactorColor + ReactorIcon + "  Reactor Bo" + DefaultColor + "ost";
+    if (c < 0.33) return ReactorColor + ReactorIcon + "  Reactor B" + DefaultColor + "oost";
+    if (c < 0.41) return ReactorColor + ReactorIcon + "  Reactor " + DefaultColor + "Boost";
+    if (c < 0.49) return ReactorColor + ReactorIcon + "  Reacto" + DefaultColor + "r Boost";
+    if (c < 0.57) return ReactorColor + ReactorIcon + "  React" + DefaultColor + "or Boost";
+    if (c < 0.65) return ReactorColor + ReactorIcon + "  Reac" + DefaultColor + "tor Boost";
+    if (c < 0.73) return ReactorColor + ReactorIcon + "  Rea" + DefaultColor + "ctor Boost";
+    if (c < 0.81) return ReactorColor + ReactorIcon + "  Re" + DefaultColor + "actor Boost";
+    if (c < 0.89) return ReactorColor + ReactorIcon + "  R" + DefaultColor + "eactor Boost";
+    return ReactorColor + ReactorIcon + DefaultColor + "  Reactor Boost";
 }
 
 bool Truthy(uint num) {

--- a/Core/Util.as
+++ b/Core/Util.as
@@ -4,22 +4,22 @@ m 2023-07-19
 */
 
 // Will be written out when VehicleState is updated
-array<CSceneVehicleVis@> AllVehicleVisWithoutPB(ISceneVis@ scene) {
-    auto @vis = VehicleState::GetAllVis(scene);
-    if (vis.Length < 3) return vis; // PB ghost already hidden
+CSceneVehicleVis@[] AllVehicleVisWithoutPB(ISceneVis@ scene) {
+    auto @allVis = VehicleState::GetAllVis(scene);
+    if (allVis.Length < 3) return allVis; // PB ghost already hidden
 
-    for (uint i = 0; i <= vis.Length - 2; i++) {
+    for (uint i = 0; i <= allVis.Length - 2; i++) {
         for (uint j = i; j <= 6; j++) {
-            if (i < vis.Length - 1) {
-                if (IsSameVehicle(vis[i], vis[j])) {
-                    vis.RemoveAt(j);
-                    vis.RemoveAt(i);
-                    return vis;
+            if (i < allVis.Length - 1) {
+                if (IsSameVehicle(allVis[i], allVis[j])) {
+                    allVis.RemoveAt(j);
+                    allVis.RemoveAt(i);
+                    return allVis;
                 }
             } else break;
         }
     }
-    return vis;  // should never happen
+    return allVis;  // should never happen
 }
 
 // I'm well aware this is garbage

--- a/Core/Util.as
+++ b/Core/Util.as
@@ -54,3 +54,12 @@ bool Truthy(uint num) {
         return true;
     return false;
 }
+
+string TurboText(float c) {
+    if (c == 0)  return TurboColor + Icons::ArrowCircleUp + "  Turbo";
+    if (c < 0.2) return TurboColor + Icons::ArrowCircleUp + "  Turb" + DefaultColor + "o";
+    if (c < 0.4) return TurboColor + Icons::ArrowCircleUp + "  Tur" + DefaultColor + "bo";
+    if (c < 0.6) return TurboColor + Icons::ArrowCircleUp + "  Tu" + DefaultColor + "rbo";
+    if (c < 0.8) return TurboColor + Icons::ArrowCircleUp + "  T" + DefaultColor + "urbo";
+    return TurboColor + Icons::ArrowCircleUp + DefaultColor + "  Turbo";
+}

--- a/Main.as
+++ b/Main.as
@@ -1,6 +1,6 @@
 /*
 c 2023-05-04
-m 2023-07-19
+m 2023-07-20
 */
 
 void Main() {
@@ -44,7 +44,8 @@ void Main() {
                 throw("null_car");
             }
 
-            ReactorFinalCountdown = Dev::GetOffsetFloat(vis, 0x3DC);
+            LastTurboLevel        = Dev::GetOffsetUint32(vis, 976);
+            ReactorFinalCountdown = Dev::GetOffsetFloat(vis, 988);
 
             ReactorLevel = uint(car.ReactorBoostLvl);
             ReactorType  = uint(car.ReactorBoostType);
@@ -66,7 +67,16 @@ void Main() {
             else if (SlowMo == 0.185193) SlowMoColor = ORANGE;
             else                         SlowMoColor = RED;
 
-            TurboColor = Turbo ? GREEN : DefaultColor;
+            if (Turbo) {
+                switch (LastTurboLevel) {
+                    case 1: TurboColor = YELLOW; break;
+                    case 2: TurboColor = RED;    break;
+                    case 3: TurboColor = YELLOW; break;  // roulette 1
+                    case 4: TurboColor = CYAN;   break;  // roulette 2
+                    case 5: TurboColor = PURPLE; break;  // roulette 3
+                    default: break;
+                }
+            } else TurboColor = DefaultColor;
 
             auto script = cast<CSmScriptPlayer@>(playground.Arena.Players[0].ScriptAPI);
             ForcedAccel = Truthy(script.HandicapForceGasDuration);

--- a/Main.as
+++ b/Main.as
@@ -1,7 +1,12 @@
 /*
 c 2023-05-04
-m 2023-07-20
+m 2023-07-23
 */
+
+void RenderMenu() {
+    if (UI::MenuItem("\\$F00" + Icons::React + "\\$G Current Effects", "", Settings::Show))
+        Settings::Show = !Settings::Show;
+}
 
 void Main() {
     @font = UI::LoadFont("DroidSans.ttf", Settings::FontSize, -1, -1, true, true, true);
@@ -100,6 +105,8 @@ void Main() {
 }
 
 void Render() {
+    if (!Settings::Show) return;
+
     auto app = cast<CTrackMania@>(GetApp());
     try {
         auto sequence = app.CurrentPlayground.UIConfigs[0].UISequence;

--- a/Main.as
+++ b/Main.as
@@ -1,6 +1,6 @@
 /*
 c 2023-05-04
-m 2023-07-04
+m 2023-07-19
 */
 
 void Main() {
@@ -11,7 +11,7 @@ void Main() {
             auto app = cast<CTrackMania@>(GetApp());
             auto playground = cast<CSmArenaClient@>(app.CurrentPlayground);
             if (playground is null) throw("null_pg");
-            auto serverInfo = cast<CTrackManiaNetworkServerInfo>(app.Network.ServerInfo);
+            auto serverInfo = cast<CTrackManiaNetworkServerInfo@>(app.Network.ServerInfo);
 
             array<CSceneVehicleVis@> cars;  // annoying workaround - conditional vars are scoped, CSceneVehicleVis is uninstantiable
             if (playground.UIConfigs[0].UISequence != CGamePlaygroundUIConfig::EUISequence::Playing) {
@@ -39,7 +39,7 @@ void Main() {
             }
             ReactorLevel = uint(car.ReactorBoostLvl);
             ReactorType  = uint(car.ReactorBoostType);
-            SlowMo       = car.BulletTimeNormed;
+            SlowMo       = car.SimulationTimeCoef;
             Turbo        = car.IsTurbo;
 
             if      (ReactorLevel == 0) ReactorColor = DefaultColor;
@@ -50,13 +50,15 @@ void Main() {
             else if (ReactorType == 1) ReactorIcon = Icons::ChevronUp;
             else                       ReactorIcon = Icons::ChevronDown;
 
-            if      (SlowMo == 0)  SlowMoColor = DefaultColor;
-            else if (SlowMo > 0.5) SlowMoColor = RED;
-            else                   SlowMoColor = YELLOW;
+            if      (SlowMo == 1)        SlowMoColor = DefaultColor;
+            else if (SlowMo == 0.57)     SlowMoColor = GREEN;
+            else if (SlowMo == 0.3249)   SlowMoColor = YELLOW;
+            else if (SlowMo == 0.185193) SlowMoColor = ORANGE;
+            else                         SlowMoColor = RED;
 
             TurboColor = Turbo ? GREEN : DefaultColor;
 
-            auto script = cast<CSmScriptPlayer>(playground.Arena.Players[0].ScriptAPI);
+            auto script = cast<CSmScriptPlayer@>(playground.Arena.Players[0].ScriptAPI);
             ForcedAccel = Truthy(script.HandicapForceGasDuration);
             NoBrakes    = Truthy(script.HandicapNoBrakesDuration);
             NoEngine    = Truthy(script.HandicapNoGasDuration);

--- a/Main.as
+++ b/Main.as
@@ -50,6 +50,7 @@ void Main() {
             ReactorType  = uint(car.ReactorBoostType);
             SlowMo       = car.SimulationTimeCoef;
             Turbo        = car.IsTurbo;
+            TurboTime    = car.TurboTime;
 
             if      (ReactorLevel == 0) ReactorColor = DefaultColor;
             else if (ReactorLevel == 1) ReactorColor = YELLOW;
@@ -119,7 +120,7 @@ void Render() {
     if (Settings::NoSteerShow)     UI::Text(NoSteerColor     + Icons::ArrowsH             + "  No Steering");
     if (Settings::ReactorShow)     UI::Text(ReactorText(ReactorFinalCountdown));
     if (Settings::SlowMoShow)      UI::Text(SlowMoColor      + Icons::ClockO              + "  Slow-Mo");
-    if (Settings::TurboShow)       UI::Text(TurboColor       + Icons::ArrowCircleUp       + "  Turbo");
+    if (Settings::TurboShow)       UI::Text(TurboText(TurboTime));
     UI::End();
     UI::PopFont();
 }

--- a/Main.as
+++ b/Main.as
@@ -20,16 +20,15 @@ void Main() {
                 if (serverInfo.CurGameModeStr.EndsWith("_Online")) {
                     auto player = cast<CSmPlayer@>(playground.GameTerminals[0].GUIPlayer);
                     @vis = VehicleState::GetVis(app.GameScene, player);
-                    @car = vis.AsyncState;
                 } else {
                     @vis = VehicleState::GetAllVis(app.GameScene)[0];
-                    @car = vis.AsyncState;
                 }
             } else {
                 auto @allVis = AllVehicleVisWithoutPB(app.GameScene);
-                @vis = allVis[allVis.Length - 1];
-                @car = vis.AsyncState;  // latest record clicked is shown (usually, still buggy)
+                @vis = allVis[allVis.Length - 1];  // latest record clicked is shown (usually, still buggy)
             }
+
+            @car = vis.AsyncState;
 
             if (car is null) {
                 ReactorLevel = 0;

--- a/Main.as
+++ b/Main.as
@@ -13,6 +13,8 @@ void Main() {
 
     while (true) {
         try {
+            if (!Settings::Show) throw("no_show");
+
             auto app = cast<CTrackMania@>(GetApp());
             auto playground = cast<CSmArenaClient@>(app.CurrentPlayground);
             if (playground is null) throw("null_pg");

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Displays current effects on your Trackmania 2020 car.
 - No Steering
 - Reactor Boost (red/yellow, up/down, last-second timer)
 - Slow-Mo (all 4 levels)
-- Turbo (yes/no)
+- Turbo (all 5 levels, timer)
 - Editor playtest
 - Viewing records (kind of)
 - Online
@@ -19,5 +19,5 @@ Displays current effects on your Trackmania 2020 car.
 - Cruise Control
 - Fragile
 - Reactor Boost (full 6-second timer - the only reason I started this)
-- Turbo (red/yellow)
+- Slow-Mo (timer)
 - More settings (colors, fonts, etc.)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Displays current effects on your Trackmania 2020 car.
 - No Brakes
 - No Grip
 - No Steering
-- Reactor Boost (red/yellow + up/down)
-- Slow-Mo (levels 1 + 2)
+- Reactor Boost (red/yellow, up/down, last-second timer)
+- Slow-Mo (all 4 levels)
 - Turbo (yes/no)
 - Editor playtest
 - Viewing records (kind of)
@@ -18,7 +18,6 @@ Displays current effects on your Trackmania 2020 car.
 - Acceleration penalty
 - Cruise Control
 - Fragile
-- Reactor Boost (timer - the entire reason I started this)
-- Slow-Mo (levels 3 + 4)
+- Reactor Boost (full 6-second timer - the entire reason I started this)
 - Turbo (red/yellow)
 - More settings (colors, fonts, etc.)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ Displays current effects on your Trackmania 2020 car.
 - Acceleration penalty
 - Cruise Control
 - Fragile
-- Reactor Boost (full 6-second timer - the entire reason I started this)
+- Reactor Boost (full 6-second timer - the only reason I started this)
 - Turbo (red/yellow)
 - More settings (colors, fonts, etc.)

--- a/info.toml
+++ b/info.toml
@@ -2,7 +2,7 @@
 name     = "Current Effects"
 author   = "Ezio414"
 category = "Overlay"
-version  = "0.4.1"
+version  = "0.5.0"
 siteid   = 382
 
 [script]


### PR DESCRIPTION
NEW:
- reactor boost final-second timer (first 5 seconds are still a mystery)
- remaining slow-mo levels (now 4 total)
- turbo levels (5 total)
- turbo timer
- menu item toggle

FIXED:
- watching replay (just what was broken in the July 2023 update, it's still buggy like before)
- global toggle more inclusive